### PR TITLE
Copy Only Gradient Code To Clipboard

### DIFF
--- a/lib/models/linear_style_gradient.dart
+++ b/lib/models/linear_style_gradient.dart
@@ -10,20 +10,12 @@ class LinearStyleGradient extends AbstractGradient {
       : super(colorList: colorList, gradientDirection: gradientDirection);
 
   String get _widgetStringTemplate =>
-      '''class PreviewScreen extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
+      '''LinearGradient(
           colors: ${getColorList()},
           begin: $_beginAlignment,
           end: $_endAlignment,
-        ),
-      ),
-    );
-  }
-}''';
+        )
+      ''';
 
   Alignment get _beginAlignment {
     Alignment alignment;

--- a/lib/models/radial_style_gradient.dart
+++ b/lib/models/radial_style_gradient.dart
@@ -12,20 +12,12 @@ class RadialStyleGradient extends AbstractGradient {
   final double _radialGradientRadius = 0.8;
 
   String get _widgetStringTemplate =>
-      '''class PreviewScreen extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        gradient: RadialGradient(
+      '''RadialGradient(
           colors: ${getColorList()},
           center: $_centerAlignment,
           radius: $_radialGradientRadius,
-        ),
-      ),
-    );
-  }
-}''';
+        )
+        ''';
 
   Alignment get _centerAlignment {
     Alignment alignment;


### PR DESCRIPTION
This PR updates the widget string template for linear and radial style gradients.
The app now copies only the gradient code to the clipboard.

