### PR TITLE
Update Buttons

### DIFF
--- a/lib/data/app_colors.dart
+++ b/lib/data/app_colors.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
-  static const Color grey = Color(0xfff1f4f8);
+  static final Color grey = Colors.grey.shade200;
   static const Color darkGrey = Color(0xff3d4853);
   static const Color white = Colors.white;
   static const Color black = Colors.black;

--- a/lib/ui/widgets/buttons/compact_buttons/direction_button.dart
+++ b/lib/ui/widgets/buttons/compact_buttons/direction_button.dart
@@ -29,7 +29,7 @@ class DirectionButton extends StatelessWidget {
           onGradientDirectionChanged(gradientDirection);
         },
         foregroundColor: Colors.black,
-        backgroundColor: isSelected ? greyColor : Colors.white,
+        backgroundColor: isSelected ? greyColor : Colors.transparent,
         borderSide: BorderSide(
           color: greyColor,
         ));

--- a/lib/ui/widgets/generator_widgets/selection_widgets/color_selection_widget.dart
+++ b/lib/ui/widgets/generator_widgets/selection_widgets/color_selection_widget.dart
@@ -37,13 +37,16 @@ class ColorSelectionWidget extends StatelessWidget {
           children: List.generate(
             colorList.length,
             (index) {
+                            final int firstIconIndex = 0;
+
+
               final Color color = colorList.elementAt(index);
               final int lastIndex = colorList.length - 1;
 
               return Row(
                 children: [
-                  if (index != 0)
-                    SizedBox(width: AppDimensions.compactButtonPadding),
+                  if (index != firstIconIndex)
+                    SizedBox(width: AppDimensions.compactButtonMargin),
                   CompactButton(
                     child: SizedBox.shrink(),
                     onPressed: () {
@@ -60,7 +63,7 @@ class ColorSelectionWidget extends StatelessWidget {
                     ),
                   ),
                   if (index == lastIndex)
-                    SizedBox(width: AppDimensions.compactButtonPadding),
+                    SizedBox(width: AppDimensions.compactButtonMargin),
                   if (index == lastIndex)
                     CompactButton(
                       child: Text(AppStrings.random),

--- a/lib/ui/widgets/generator_widgets/selection_widgets/style_selection_widget.dart
+++ b/lib/ui/widgets/generator_widgets/selection_widgets/style_selection_widget.dart
@@ -23,7 +23,7 @@ class StyleSelectionWidget extends StatelessWidget {
         gradientStyle == GradientStyle.radial;
 
     final Color selectedStyleButtonColor = AppColors.grey;
-    final Color unselectedStyleButtonColor = AppColors.white;
+    final Color unselectedStyleButtonColor = Colors.transparent;
 
     final Color linearStyleButtonColor = isLinearGradientStyleSelected
         ? selectedStyleButtonColor


### PR DESCRIPTION
This PR updates the `DirectionButton` widgets to use `Colors.transparent` instead of `Colors.white` for their default state. 