### PR TITLE
Allow GitHub Action Workflow Run For Forks

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -5,7 +5,6 @@ name: Deploy to Firebase Hosting on PR
 'on': pull_request
 jobs:
   build_and_preview:
-    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This commit removes the line below:

https://github.com/victoreronmosele/flutter_gradient_generator/blob/cac1e93703b168a0aaaa64164c0690e5c0dfc3c6/.github/workflows/firebase-hosting-pull-request.yml#L8

The line of code prevents PRs from forks from triggering the workflow.