### PR TITLE
Revert "Allow GitHub Action Workflow Run For Forks"

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -5,6 +5,7 @@ name: Deploy to Firebase Hosting on PR
 'on': pull_request
 jobs:
   build_and_preview:
+    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Reverts victoreronmosele/flutter_gradient_generator#45 as PRs from forks don't have access to repository secrets and the secret is needed for the preview deployment. 

See [#43 ](https://github.com/victoreronmosele/flutter_gradient_generator/pull/43#issuecomment-981589723)