### PR TITLE
Fix UI Update Bugs

### DIFF
--- a/lib/ui/widgets/header/widgets/tool_bar.dart
+++ b/lib/ui/widgets/header/widgets/tool_bar.dart
@@ -34,20 +34,23 @@ class ToolBar extends StatelessWidget {
             child: Row(
               children: [
                 Expanded(
-                  child: InkWell(
-                    onTap: () {
-                      launchUrl(
-                        Uri.parse('/'),
-
-                        /// Open in current tab
-                        webOnlyWindowName: '_self',
-                      );
-                    },
-                    child: Text(
-                      AppStrings.appTitle,
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                            color: AppColors.white,
-                          ),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: InkWell(
+                      onTap: () {
+                        launchUrl(
+                          Uri.parse('/'),
+                    
+                          /// Open in current tab
+                          webOnlyWindowName: '_self',
+                        );
+                      },
+                      child: Text(
+                        AppStrings.appTitle,
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                              color: AppColors.white,
+                            ),
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
This PR fixes the bug in the UI update where empty space in the toolbar reloads the app. 

Now clicking on the empty space in the toolbar doesn't reload the app. 

### Before:

https://github.com/victoreronmosele/flutter_gradient_generator/assets/19398044/307374a2-b9b3-4b22-a06c-b499df3bda51


### After:

https://github.com/victoreronmosele/flutter_gradient_generator/assets/19398044/81c38a65-6c6e-4a89-8932-5ed22436c9b3



Fixes #76 

